### PR TITLE
Fix: Prevent user from getting stuck in Add Passage

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,6 +8,7 @@ import { SplashScreen } from '@ionic-native/splash-screen';
 import { SocialSharing } from "@ionic-native/social-sharing";
 
 import { MyApp } from './app.component';
+import { AddPassagePage } from '../pages/add-passage/add-passage';
 import { BiblePage } from '../pages/bible/bible';
 import { MenuPage } from '../pages/menu/menu';
 import { RecitePassagePage } from "../pages/recite-passage/recite-passage";
@@ -20,6 +21,7 @@ import { SearchPage } from "../pages/search/search";
 @NgModule({
   declarations: [
     MyApp,
+    AddPassagePage,
     BiblePage,
     MenuPage,
     RecitePassagePage,
@@ -35,6 +37,7 @@ import { SearchPage } from "../pages/search/search";
   bootstrap: [IonicApp],
   entryComponents: [
     MyApp,
+    AddPassagePage,
     BiblePage,
     MenuPage,
     RecitePassagePage,

--- a/src/pages/add-passage/add-passage.html
+++ b/src/pages/add-passage/add-passage.html
@@ -1,17 +1,8 @@
-<!--
-  Generated template for the AddPassagePage page.
-
-  See http://ionicframework.com/docs/components/#navigation for more info on
-  Ionic pages and navigation.
--->
 <ion-header>
   <ion-navbar>
-    <ion-title>Add Passage</ion-title>
-    <ion-buttons>
-      <!--<button ion-button icon-only (click)="share()">
-        <ion-icon name="share"></ion-icon>
-      </button>-->
-    </ion-buttons>
+    <ion-title>
+      Add Passage
+    </ion-title>
   </ion-navbar>
 </ion-header>
 

--- a/src/pages/bible/bible.html
+++ b/src/pages/bible/bible.html
@@ -3,15 +3,14 @@
     <button ion-button icon-only menuToggle>
       <ion-icon name="menu"></ion-icon>
     </button>
-  <ion-title>{{screenTitle}}</ion-title>
+
+    <ion-title>
+      {{screenTitle}}
+    </ion-title>
   </ion-navbar>
 </ion-header>
+
 <ion-content padding id="bible">
-  <ion-fab bottom right>
-    <button ion-fab (click)="addPassage()" (press)="onPressFAB()">
-      <ion-icon name="add"></ion-icon>
-    </button>
-  </ion-fab>
   <ion-list>
     <button ion-item ngClass={{overdue(passage.timestamp)}} *ngFor="let passage of passages" (press)="pressPassage(passage)" (click)="selectPassage(passage)">
       <h2 class="verse__reference">{{passage.reference}}</h2>
@@ -19,3 +18,9 @@
     </button>
   </ion-list>
 </ion-content>
+
+<ion-fab bottom right>
+  <button ion-fab (click)="addPassage()">
+    <ion-icon name="add"></ion-icon>
+  </button>
+</ion-fab>

--- a/src/pages/bible/bible.ts
+++ b/src/pages/bible/bible.ts
@@ -219,23 +219,30 @@ export class BiblePage {
     return 'verse verse--normal';
   }
 
-  ionViewDidLoad() {
-    console.log('ionViewDidLoad BiblePage');
-  }
+  ionViewDidLoad() {}
 
   addPassage() {
-    this.navCtrl.push('AddPassagePage', { folder : this.folder });
+    this.navCtrl.push(AddPassagePage, {
+      folder : this.folder
+    });
   }
 
   selectPassage = (passage) => {
     var index = this.passagesInFolder.indexOf(passage);
+
     if (index > -1) {
-      this.navCtrl.push(RecitePassagePage, { folder : this.folder, passagesInFolder : this.passagesInFolder, index : index });
+      this.navCtrl.push(RecitePassagePage, {
+        folder : this.folder,
+        passagesInFolder : this.passagesInFolder,
+        index : index
+      });
       return;
     }
 
     // Open folder
-    this.navCtrl.push(BiblePage, { folder: passage.reference });
+    this.navCtrl.push(BiblePage, {
+      folder: passage.reference
+    });
   }
 
   deleteFolder = (passage) => {


### PR DESCRIPTION
## Problem

App could get stuck on the _Add Passage_ screen with no way back because it wasn't registered in `app.module.ts`.

## Resolution

Registers `AddPassagePage` in `app.module.ts` and updated the FAB button press function with new navigation route.

## Additonal

Also tidy up some code formatting to make the navigation functions easier to see what is being sent through.