### PR TITLE
(#56) Fix: Audio for books starting with a numeral

### DIFF
--- a/src/pages/recite-passage/recite-passage.ts
+++ b/src/pages/recite-passage/recite-passage.ts
@@ -433,7 +433,7 @@ export class RecitePassagePage {
   onAudioToggle = () => {
     if (!this.passageAudio) {
       const progressBar = <HTMLElement>document.querySelector('.audioPlayer__scrubber__location');
-      const passageUrl = `http://www.esvapi.org/v2/rest/passageQuery?key=${ ENV.esvApiKey }&output-format=mp3&passage=${ this.reference.replace(' ', '.')}`
+      const passageUrl = `http://www.esvapi.org/v2/rest/passageQuery?key=${ ENV.esvApiKey }&output-format=mp3&passage=${ this.reference.replace(/\s/g, '%20')}`
       this.passageAudio = new Audio(passageUrl);
       this.passageAudio.play();
       this.playPauseIcon = 'pause';


### PR DESCRIPTION
3 John returned audio from 1 John, 2 Samuel returned 1 Samuel. This is
fixed.

This should go live urgently as `0.1.1`